### PR TITLE
Update Iconify plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -86,8 +86,8 @@
 	{
 		"id": "iconify-figma-plus",
 		"github": "https://github.com/iconify/iconify-figma-plus/",
-		"approvedVersion": "1.0.0",
-		"approvedCommit": "2799c917a2aef02e4f700d91b94f2680951cdbf1"
+		"approvedVersion": "1.0.1",
+		"approvedCommit": "89bd7aa5adff8400fb504c4dc5549828eb9109ab"
 	},
 	{
 		"id": "figma-to-marvel",


### PR DESCRIPTION
This is a minor update, it only changes how variables 'figma' and 'figmaPlus' are defined. Workaround for bug I've reported in figma-plus repository: https://github.com/figma-plus/figma-plus/issues/18

Bug is variable window.figma is undefined when plug-in is initialised. This version uses variable 'figma' only when plug-in is activated, so Figma finished initialising and variable is defined.